### PR TITLE
Print TCP links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "log",
  "smoltcp",
  "spin 0.9.8",
+ "spinlock",
 ]
 
 [[package]]
@@ -1923,6 +1924,7 @@ dependencies = [
  "axfeat",
  "axhal",
  "axlog",
+ "axnet",
  "axprocess",
  "axruntime",
  "axsignal",

--- a/modules/axnet/Cargo.toml
+++ b/modules/axnet/Cargo.toml
@@ -30,6 +30,7 @@ axtask = { path = "../axtask" }
 axdriver = { path = "../axdriver", features = ["net"] }
 axio = { path = "../../crates/axio" }
 crate_interface = { path = "../../crates/crate_interface" }
+spinlock = { path = "../../crates/spinlock" }
 
 [dependencies.smoltcp]
 git = "https://github.com/rcore-os/smoltcp.git"

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -145,6 +145,10 @@ impl TcpSocket {
             // TODO: check remote addr unreachable
             let remote_endpoint = from_core_sockaddr(remote_addr);
             let bound_endpoint = self.bound_endpoint()?;
+
+            // collect the tcp ports
+            (TCP_LINKS.lock().borrow_mut() as &mut Vec<(u16, u16)>).push((bound_endpoint.port, remote_endpoint.port));
+
             #[cfg(not(feature = "ip"))]
             let iface = &super::ETH0.iface;
 
@@ -167,9 +171,6 @@ impl TcpSocket {
                         socket.remote_endpoint().unwrap(),
                     ))
                 })?;
-
-            // collect the tcp ports
-            (TCP_LINKS.lock().borrow_mut() as &mut Vec<(u16, u16)>).push((local_endpoint.port, remote_endpoint.port));
 
             unsafe {
                 // SAFETY: no other threads can read or write these fields as we

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -12,6 +12,11 @@ use smoltcp::iface::SocketHandle;
 use smoltcp::socket::tcp::{self, ConnectError, State};
 use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
 
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::borrow::BorrowMut;
+use spinlock::SpinNoIrq;
+
 use super::addr::{from_core_sockaddr, into_core_sockaddr, is_unspecified, UNSPECIFIED_ENDPOINT};
 use super::{SocketSetWrapper, LISTEN_TABLE, SOCKET_SET};
 
@@ -48,6 +53,16 @@ pub struct TcpSocket {
 unsafe impl Sync for TcpSocket {}
 
 impl TcpSocket {
+    /// Get the TCP links
+    pub fn tcp_links() -> Vec<(u16, u16)> {
+        let mut ports = Vec::new();
+        for port in (TCP_LINKS.lock().borrow() as &Vec<(u16, u16)>).iter() {
+            ports.push(*port);
+        }
+
+        ports
+    }
+
     /// Creates a new TCP socket.
     pub const fn new() -> Self {
         Self {
@@ -152,6 +167,10 @@ impl TcpSocket {
                         socket.remote_endpoint().unwrap(),
                     ))
                 })?;
+
+            // collect the tcp ports
+            (TCP_LINKS.lock().borrow_mut() as &mut Vec<(u16, u16)>).push((local_endpoint.port, remote_endpoint.port));
+
             unsafe {
                 // SAFETY: no other threads can read or write these fields as we
                 // have changed the state to `BUSY`.
@@ -666,3 +685,5 @@ fn get_ephemeral_port() -> AxResult<u16> {
     }
     ax_err!(AddrInUse, "no avaliable ports!")
 }
+
+pub static TCP_LINKS: SpinNoIrq<Vec<(u16, u16)>> = SpinNoIrq::new(Vec::new());

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+make A=apps/oscomp ARCH=riscv64 NET=y LOG=error QEMU_LOG=y FEATURES="img signal net" run
+

--- a/ulib/axstarry/syscall_entry/Cargo.toml
+++ b/ulib/axstarry/syscall_entry/Cargo.toml
@@ -72,6 +72,7 @@ syscall_task = ["dep:syscall_task"]
 axfeat = { path = "../../../api/axfeat" }
 arceos_api = { path = "../../../api/arceos_api" }
 axlog = { path = "../../../modules/axlog" }
+axnet = { path = "../../../modules/axnet" }
 axruntime = { path = "../../../modules/axruntime" }
 axhal = { path = "../../../modules/axhal" }
 axtask = { path = "../../../modules/axtask" }

--- a/ulib/axstarry/syscall_entry/src/test.rs
+++ b/ulib/axstarry/syscall_entry/src/test.rs
@@ -4,9 +4,10 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use axnet::TcpSocket;
 use axhal::arch::{flush_tlb, write_page_table_root};
 use axhal::KERNEL_PROCESS_ID;
-use axlog::info;
+use axlog::{error, info};
 use axprocess::link::{create_link, FilePath};
 use axprocess::{wait_pid, yield_now_task, PID2PC};
 use axruntime::KERNEL_PAGE_TABLE;
@@ -433,6 +434,13 @@ impl TestResult {
 
     /// 完成了所有测例之后，打印测试结果
     pub fn show_result(&self) {
+        let tcp_links: &Vec<(u16, u16)> = &TcpSocket::tcp_links();
+        error!("total built {} tcp link(s)", tcp_links.len());
+
+        for port in tcp_links.iter() {
+            error!("tcp link src_port:{} dst_port:{}", port.0, port.1);
+        }
+
         info!(
             " --------------- all test ended, passed {} / {} --------------- ",
             self.accepted, self.sum


### PR DESCRIPTION
I am using a global variable to collect the port pairs for printing in the `ulib` level. But global variable is evil. I do this because it's easy.. Yet to figure out the best way of handling this kind of use case. 